### PR TITLE
Add ability to specify message Handler for queue.

### DIFF
--- a/azsqs/queue.go
+++ b/azsqs/queue.go
@@ -70,7 +70,7 @@ func (q *Queue) initAddQueue() {
 	q.addTask = taskq.RegisterTask(&taskq.TaskOptions{
 		Name:            queueName + ":add-message",
 		Handler:         taskq.HandlerFunc(q.addBatcherAdd),
-		FallbackHandler: msgutil.UnwrapMessageHandler(taskq.Tasks.HandleMessage),
+		FallbackHandler: msgutil.UnwrapMessageHandler(taskq.MessageHandler(q.opt.Tasks)),
 		RetryLimit:      3,
 		MinBackoff:      time.Second,
 	})

--- a/ironmq/queue.go
+++ b/ironmq/queue.go
@@ -60,7 +60,7 @@ func (q *Queue) initAddQueue() {
 	q.addTask = taskq.RegisterTask(&taskq.TaskOptions{
 		Name:            queueName + ":add-mesage",
 		Handler:         taskq.HandlerFunc(q.add),
-		FallbackHandler: msgutil.UnwrapMessageHandler(taskq.Tasks.HandleMessage),
+		FallbackHandler: msgutil.UnwrapMessageHandler(taskq.MessageHandler(q.opt.Tasks)),
 		RetryLimit:      3,
 		MinBackoff:      time.Second,
 	})

--- a/queue.go
+++ b/queue.go
@@ -56,6 +56,9 @@ type QueueOptions struct {
 	// Optional storage interface. The default is to use Redis.
 	Storage Storage
 
+	// Optional message handler. The default is the global Tasks registry.
+	Tasks TaskRegistry
+
 	inited bool
 }
 
@@ -109,6 +112,10 @@ func (opt *QueueOptions) Init() {
 		limiter := redis_rate.NewLimiter(opt.Redis)
 		limiter.Fallback = rate.NewLimiter(opt.RateLimit, 1)
 		opt.RateLimiter = limiter
+	}
+
+	if opt.Tasks == nil {
+		opt.Tasks = &Tasks
 	}
 }
 

--- a/registry.go
+++ b/registry.go
@@ -5,13 +5,33 @@ import (
 	"sync"
 )
 
-var Tasks taskRegistry
+var Tasks TaskMap
 
-type taskRegistry struct {
+type TaskRegistry interface {
+	Get(name string) *Task
+}
+
+func MessageHandler(registry TaskRegistry) func(msg *Message) error {
+	return func(msg *Message) error {
+		task := registry.Get(msg.TaskName)
+		if task == nil {
+			return fmt.Errorf("taskq: unknown task=%q", msg.TaskName)
+		}
+
+		opt := task.Options()
+		if opt.DeferFunc != nil {
+			defer opt.DeferFunc()
+		}
+
+		return task.HandleMessage(msg)
+	}
+}
+
+type TaskMap struct {
 	m sync.Map
 }
 
-func (r *taskRegistry) Get(name string) *Task {
+func (r *TaskMap) Get(name string) *Task {
 	if v, ok := r.m.Load(name); ok {
 		return v.(*Task)
 	}
@@ -21,38 +41,35 @@ func (r *taskRegistry) Get(name string) *Task {
 	return nil
 }
 
-func (r *taskRegistry) Register(task *Task) error {
+func (r *TaskMap) Register(opt *TaskOptions) (*Task, error) {
+	opt.init()
+
+	task := &Task{
+		opt:     opt,
+		handler: NewHandler(opt.Handler),
+	}
+
+	if opt.FallbackHandler != nil {
+		task.fallbackHandler = NewHandler(opt.FallbackHandler)
+	}
+
 	name := task.Name()
 	_, loaded := r.m.LoadOrStore(name, task)
 	if loaded {
-		return fmt.Errorf("task=%q already exists", name)
+		return nil, fmt.Errorf("task=%q already exists", name)
 	}
-	return nil
+	return task, nil
 }
 
-func (r *taskRegistry) Unregister(task *Task) {
+func (r *TaskMap) Unregister(task *Task) {
 	r.m.Delete(task.Name())
 }
 
-func (r *taskRegistry) Reset() {
+func (r *TaskMap) Reset() {
 	r.m = sync.Map{}
 }
 
-func (r *taskRegistry) HandleMessage(msg *Message) error {
-	task := r.Get(msg.TaskName)
-	if task == nil {
-		return fmt.Errorf("taskq: unknown task=%q", msg.TaskName)
-	}
-
-	opt := task.Options()
-	if opt.DeferFunc != nil {
-		defer opt.DeferFunc()
-	}
-
-	return task.HandleMessage(msg)
-}
-
-func (r *taskRegistry) Range(fn func(name string, task *Task) bool) {
+func (r *TaskMap) Range(fn func(name string, task *Task) bool) {
 	r.m.Range(func(key, value interface{}) bool {
 		return fn(key.(string), value.(*Task))
 	})

--- a/task.go
+++ b/task.go
@@ -86,22 +86,12 @@ type Task struct {
 }
 
 func RegisterTask(opt *TaskOptions) *Task {
-	opt.init()
-
-	t := &Task{
-		opt: opt,
-	}
-
-	t.handler = NewHandler(opt.Handler)
-	if opt.FallbackHandler != nil {
-		t.fallbackHandler = NewHandler(opt.FallbackHandler)
-	}
-
-	if err := Tasks.Register(t); err != nil {
+	task, err := Tasks.Register(opt)
+	if err != nil {
 		panic(err)
 	}
 
-	return t
+	return task
 }
 
 func (t *Task) Name() string {


### PR DESCRIPTION
Also export TaskRegistry if users prefer not to use global Tasks
TaskRegistry as the handler for all queues.

fixes #45 

Signed-off-by: Silas Davis <silas@monax.io>