### PR TITLE
fixed panics on msg.Name != "" & redis is disabled

### DIFF
--- a/queue.go
+++ b/queue.go
@@ -108,7 +108,11 @@ func (opt *QueueOptions) Init() {
 	}
 
 	if opt.Storage == nil {
-		opt.Storage = newRedisStorage(opt.Redis)
+		if opt.Redis != nil {
+			opt.Storage = newRedisStorage(opt.Redis)
+		} else {
+			opt.Storage = localStorage{}
+		}
 	}
 
 	if !opt.RateLimit.IsZero() && opt.RateLimiter == nil && opt.Redis != nil {

--- a/storage.go
+++ b/storage.go
@@ -1,0 +1,64 @@
+package taskq
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/hashicorp/golang-lru/simplelru"
+)
+
+type Storage interface {
+	Exists(ctx context.Context, key string) bool
+}
+
+var _ Storage = (*localStorage)(nil)
+var _ Storage = (*redisStorage)(nil)
+
+// LOCAL
+
+type localStorage struct {
+	mu    sync.Mutex
+	cache *simplelru.LRU
+}
+
+func (s localStorage) Exists(_ context.Context, key string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.cache == nil {
+		var err error
+		s.cache, err = simplelru.NewLRU(128000, nil)
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	_, ok := s.cache.Get(key)
+	if ok {
+		return true
+	}
+
+	s.cache.Add(key, nil)
+	return false
+}
+
+// REDIS
+
+type redisStorage struct {
+	redis Redis
+}
+
+func newRedisStorage(redis Redis) redisStorage {
+	return redisStorage{
+		redis: redis,
+	}
+}
+
+func (s redisStorage) Exists(ctx context.Context, key string) bool {
+	val, err := s.redis.SetNX(ctx, key, "", 24*time.Hour).Result()
+	if err != nil {
+		return true
+	}
+	return !val
+}


### PR DESCRIPTION
When using the tool without `redis`, if the `Name` of a taskq.Message is set, we end up with the following error:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x48 pc=0xa3dcac]

goroutine 1 [running]:
github.com/vmihailenco/taskq/v3.redisStorage.Exists(0x0, 0x0, 0xf1bf30, 0xc00002a0b8, 0xc0005fe120, 0x13, 0x13)
        /home/max/go/pkg/mod/github.com/vmihailenco/taskq/v3@v3.2.3/taskq.go:66 +0x4c
github.com/vmihailenco/taskq/v3/memqueue.(*Queue).isDuplicate(0xc00059e980, 0xc000580b60, 0x0)
        /home/max/go/pkg/mod/github.com/vmihailenco/taskq/v3@v3.2.3/memqueue/queue.go:263 +0x8e
github.com/vmihailenco/taskq/v3/memqueue.(*Queue).Add(0xc00059e980, 0xc000580b60, 0x12, 0xc00059ab70)
        /home/max/go/pkg/mod/github.com/vmihailenco/taskq/v3@v3.2.3/memqueue/queue.go:179 +0x5
```