### PR TITLE
Fix: redisq/queue.go

### DIFF
--- a/redisq/queue.go
+++ b/redisq/queue.go
@@ -352,7 +352,7 @@ func (q *Queue) cleanZombieConsumers(ctx context.Context) (int, error) {
 			continue
 		}
 
-		if time.Duration(consumer.Idle)*time.Second > q.opt.ConsumerIdleTimeout {
+		if time.Duration(consumer.Idle)*time.Millisecond > q.opt.ConsumerIdleTimeout {
 			_ = q.redis.XGroupDelConsumer(ctx, q.stream, q.streamGroup, consumer.Name).Err()
 		}
 	}


### PR DESCRIPTION
line 355: time.Second to time.Millisecond (representing consumer.Idle)