### PR TITLE
Allow to set duration for unique messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,9 +164,12 @@ for i := 0; i < 100; i++ {
 ## Message deduplication
 
 If a `Message` has a `Name` then this will be used as unique identifier and messages with the same
-name will be deduplicated (i.e. not processed again) within a 24 hour period (or possibly longer if
-not evicted from local cache after that period). Where `Name` is omitted then non deduplication
-occurs and each message will be processed. `Task`'s `WithMessage` and `WithArgs` both produces
+name will be deduplicated (i.e. not processed again) within within a `UniqueDuration` period 
+(by default, it is 24 hours, if you don't set it in `QueueOptions`).
+
+Where `Name` is omitted then non deduplication occurs and each message will be processed. 
+
+`Task`'s `WithMessage` and `WithArgs` both produces
 messages with no `Name` so will not be deduplicated. `OnceWithArgs` sets a name based off a
 consistent hash of the arguments and a quantised period of time (i.e. 'this hour', 'today') passed
 to `OnceWithArgs` a `period`. This guarantees that the same function will not be called with the

--- a/queue.go
+++ b/queue.go
@@ -71,6 +71,10 @@ type QueueOptions struct {
 	// We can change it to a bigger value so that it won't slowdown the redis when using redis queue.
 	// It will be between SchedulerBackoffTime and SchedulerBackoffTime+250ms.
 	SchedulerBackoffTime time.Duration
+
+	// UniqueDuration specifies the duration of the unique task name in memory.
+	// by default it is set to 24 hour.
+	UniqueDuration time.Duration
 }
 
 func (opt *QueueOptions) Init() {
@@ -122,8 +126,12 @@ func (opt *QueueOptions) Init() {
 		opt.ConsumerIdleTimeout = 6 * time.Hour
 	}
 
+	if opt.UniqueDuration == 0 {
+		opt.UniqueDuration = 24 * time.Hour
+	}
+
 	if opt.Storage == nil {
-		opt.Storage = newRedisStorage(opt.Redis)
+		opt.Storage = newRedisStorage(opt.Redis, opt.UniqueDuration)
 	}
 
 	if !opt.RateLimit.IsZero() && opt.RateLimiter == nil && opt.Redis != nil {

--- a/storage.go
+++ b/storage.go
@@ -18,12 +18,22 @@ var _ Storage = (*redisStorage)(nil)
 // LOCAL
 
 type localStorage struct {
-	mu    sync.Mutex
-	cache *simplelru.LRU
+	mu           sync.Mutex
+	cache        *simplelru.LRU
+	uniqueMsgTTL time.Duration // time to live for unique messages
 }
 
-func NewLocalStorage() Storage {
-	return &localStorage{}
+func NewLocalStorage(a ...interface{}) Storage {
+	uniqueMsgTTL := 24 * time.Hour
+	if len(a) > 0 {
+		duration, ok := a[0].(time.Duration)
+		if ok {
+			uniqueMsgTTL = duration
+		}
+	}
+	return &localStorage{
+		uniqueMsgTTL: uniqueMsgTTL,
+	}
 }
 
 func (s *localStorage) Exists(_ context.Context, key string) bool {
@@ -38,29 +48,42 @@ func (s *localStorage) Exists(_ context.Context, key string) bool {
 		}
 	}
 
-	_, ok := s.cache.Get(key)
+	preVal, ok := s.cache.Get(key)
 	if ok {
 		return true
 	}
 
-	s.cache.Add(key, nil)
+	preTime, ok := preVal.(time.Time)
+	if ok {
+		if time.Since(preTime) < s.uniqueMsgTTL {
+			return true
+		} else {
+			s.cache.Remove(key)
+			return false
+		}
+	}
+
+	s.cache.Add(key, time.Now().Add(s.uniqueMsgTTL))
+
 	return false
 }
 
 // REDIS
 
 type redisStorage struct {
-	redis Redis
+	redis        Redis
+	uniqueMsgTTL time.Duration // time to live for unique messages
 }
 
-func newRedisStorage(redis Redis) Storage {
+func newRedisStorage(redis Redis, uniqueMsgTTL time.Duration) Storage {
 	return &redisStorage{
-		redis: redis,
+		redis:        redis,
+		uniqueMsgTTL: uniqueMsgTTL,
 	}
 }
 
 func (s *redisStorage) Exists(ctx context.Context, key string) bool {
-	val, err := s.redis.SetNX(ctx, key, "", 24*time.Hour).Result()
+	val, err := s.redis.SetNX(ctx, key, "", s.uniqueMsgTTL).Result()
 	if err != nil {
 		return true
 	}

--- a/storage_test.go
+++ b/storage_test.go
@@ -1,0 +1,29 @@
+package taskq_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/vmihailenco/taskq/v3"
+)
+
+func TestNewLocalStorage(t *testing.T) {
+	localStorage := taskq.NewLocalStorage(3 * time.Second)
+	exist := localStorage.Exists(context.Background(), "local_exist")
+	if exist {
+		t.Error("Exists should return false when an new item is not in the cache")
+	}
+
+	time.Sleep(800 * time.Millisecond)
+	exist = localStorage.Exists(context.Background(), "local_exist")
+	if !exist {
+		t.Error("Exists should return true, as the item should still in the cache")
+	}
+
+	time.Sleep(2300 * time.Millisecond)
+	exist = localStorage.Exists(context.Background(), "local_exist")
+	if !exist {
+		t.Error("Exists should return false,while the life time of the item is over")
+	}
+}


### PR DESCRIPTION
Before this PR, the Unique message (by setting `Message.Name`)  is by default have to wait for 24 hours to be invalid.

with this `UniqueDuration` field , you can set your unique task being unique in any period of time.