### PR TITLE
Add wg.wait for redisq

### DIFF
--- a/redisq/queue.go
+++ b/redisq/queue.go
@@ -280,6 +280,9 @@ func (q *Queue) CloseTimeout(timeout time.Duration) error {
 	_ = q.redis.XGroupDelConsumer(
 		context.TODO(), q.stream, q.streamGroup, q.streamConsumer).Err()
 
+	// maybe place the wg.wait for redisq here?
+	q.wg.Wait()
+	
 	return nil
 }
 


### PR DESCRIPTION
wg in redisq/queue.go has no wait method called. Studied and imitated from other queue implementations.