### PR TITLE
feat: introduce Logger interface

### DIFF
--- a/internal/log.go
+++ b/internal/log.go
@@ -1,7 +1,11 @@
 package internal
 
-import (
-	"log"
-)
+type StdLogger interface {
+	Fatal(v ...interface{})
+	Fatalf(format string, v ...interface{})
+	Print(v ...interface{})
+	Println(v ...interface{})
+	Printf(format string, v ...interface{})
+}
 
-var Logger *log.Logger
+var Logger StdLogger

--- a/taskq.go
+++ b/taskq.go
@@ -15,8 +15,18 @@ func init() {
 	SetLogger(log.New(os.Stderr, "taskq: ", log.LstdFlags|log.Lshortfile))
 }
 
-func SetLogger(logger *log.Logger) {
+// SetLogger sets the main logger of the library, when not called it uses standard error.
+func SetLogger(logger Logger) {
 	internal.Logger = logger
+}
+
+// Logger is a generic logging interface used in SetLogger.
+type Logger interface {
+	Fatal(v ...interface{})
+	Fatalf(format string, v ...interface{})
+	Print(v ...interface{})
+	Println(v ...interface{})
+	Printf(format string, v ...interface{})
 }
 
 // Factory is an interface that abstracts creation of new queues.


### PR DESCRIPTION
The SetLogger function previously only accepted Logger type from the standard library. Now, it accepts a generic Logger interface. This allows to write own logging implementations easily.

Because of the import cycle, I have to copy the interface in the `internal` package. I wanted to avoid bigger refactoring or moving logging around, that is something that might be done in the future: https://github.com/vmihailenco/taskq/issues/46

I would really appreciate a minor release with this small change, it is compatible change and we would love to see logs in our zerolog adapter :-)