### PR TITLE
Prevent exponential backoff delay from overflowing

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -941,11 +941,11 @@ func exponentialBackoff(min, max time.Duration, retry int) time.Duration {
 	if retry > 0 {
 		d = min << uint(retry-1)
 	}
+	if (retry > 0 && d <= 0) || d > max {
+		return max
+	}
 	if d < min {
 		return min
-	}
-	if d > max {
-		return max
 	}
 	return d
 }


### PR DESCRIPTION
Because of the bit shifting used in the exponential backoff computation, an overflow can happen given some specific values for min/max backoff.

Here is a snippet to show the current and fixed behavior: https://go.dev/play/p/V2tno9piKly

This PR fixes it without trying to change the "normal" behavior by simply using the max backoff value when an overflow happens.