### PR TITLE
Dont automaticaly start consumer in memqueue

### DIFF
--- a/memqueue/queue.go
+++ b/memqueue/queue.go
@@ -88,6 +88,10 @@ type Queue struct {
 var _ taskq.Queue = (*Queue)(nil)
 
 func NewQueue(opt *taskq.QueueOptions) *Queue {
+	return NewQueueMaybeConsumer(true, opt)
+}
+
+func NewQueueMaybeConsumer(startConsumer bool, opt *taskq.QueueOptions) *Queue {
 	opt.Init()
 
 	q := &Queue{
@@ -95,8 +99,10 @@ func NewQueue(opt *taskq.QueueOptions) *Queue {
 	}
 
 	q.consumer = taskq.NewConsumer(q)
-	if err := q.consumer.Start(context.Background()); err != nil {
-		panic(err)
+	if startConsumer {
+		if err := q.consumer.Start(context.Background()); err != nil {
+			panic(err)
+		}
 	}
 
 	return q


### PR DESCRIPTION
We have a use case where we want to mock a redis queue in testing by using a memqueue. Our code calls https://github.com/vmihailenco/taskq/blob/v3/consumer.go#L314 which fails if the consumer is already started so we want to init our memqueue w/o starting the consumer.

We tried using https://github.com/vmihailenco/taskq/blob/v3/consumer.go#L202 immediately after we created the memqueue but this sometimes takes a very long time in our CI causing spurious flaky tests.

This change is meant to be the smallest possible change to suit our needs and not change the taskq api. Happy to re-work if you have a better suggested path to solve our use case.